### PR TITLE
feat: add template support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 Starter project with Adobe Franklin
 
 ## Environments
-- Preview: https://main--franklin-oob--arnest00.hlx.page/
-- Live: https://main--franklin-oob--arnest00.hlx.live/
+- Preview: https://main--franklin-oob--sparkbox.hlx.page/
+- Live: https://main--franklin-oob--sparkbox.hlx.live/
 
 ## Installation
 

--- a/scripts/blue.js
+++ b/scripts/blue.js
@@ -1,0 +1,5 @@
+import { loadCSS } from './lib-franklin.js';
+
+export default async function decorateTemplate() {
+  loadCSS(`${window.hlx.codeBasePath}/styles/blue.css`);
+}

--- a/scripts/red.js
+++ b/scripts/red.js
@@ -1,0 +1,5 @@
+import { loadCSS } from './lib-franklin.js';
+
+export default async function decorateTemplate() {
+  loadCSS(`${window.hlx.codeBasePath}/styles/red.css`);
+}

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -11,6 +11,8 @@ import {
   waitForLCP,
   loadBlocks,
   loadCSS,
+  toClassName,
+  getMetadata,
 } from './lib-franklin.js';
 
 const LCP_BLOCKS = []; // add your LCP blocks to the list
@@ -31,9 +33,14 @@ function buildHeroBlock(main) {
  * Builds all synthetic blocks in a container element.
  * @param {Element} main The container element
  */
-function buildAutoBlocks(main) {
+async function buildAutoBlocks(main) {
   try {
-    buildHeroBlock(main);
+    const template = toClassName(getMetadata('template'));
+
+    if (template) {
+      const mod = await import(`./${template}.js`);
+      await mod.default();
+    } else buildHeroBlock(main);
   } catch (error) {
     // eslint-disable-next-line no-console
     console.error('Auto Blocking failed', error);

--- a/styles/blue.css
+++ b/styles/blue.css
@@ -1,0 +1,3 @@
+.blue .section p {
+  color: blue;
+}

--- a/styles/red.css
+++ b/styles/red.css
@@ -1,0 +1,3 @@
+.red .section p {
+  color: red;
+}


### PR DESCRIPTION
## Changes
This WIP PR adds support for two templates: blue and red.

## Test URLs
- Before: https://main--franklin-oob--sparkbox.hlx.page/blog/article-001
- After: https://feat--add-template-support--franklin-oob--sparkbox.hlx.page/blog/article-001
